### PR TITLE
Fix: Handle missing LINE_ACCESS_TOKEN and add documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 # LINE
+# Your LINE Channel Secret, used to verify webhook requests from LINE
 LINE_CHANNEL_SECRET=xxxxxxxxxxxxxxxx
+# Your LINE Channel Access Token, required for the bot to communicate with the LINE Messaging API
 LINE_ACCESS_TOKEN=xxxxxxxxxxxxxxxx
 
 # OpenAI
+# Your OpenAI API Key
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxx
+# The OpenAI model to be used (optional, defaults to gpt-4o-mini)
 OPENAI_MODEL=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# LINE Bot Webhook for GPT Integration
+
+This project is a LINE Bot webhook that integrates with a GPT model to provide intelligent responses.
+
+## Configuration
+
+To run this project, you need to set up the following environment variables.
+
+### Mandatory Environment Variables
+
+*   **`LINE_ACCESS_TOKEN`**: Your LINE Channel Access Token. This is required for the bot to communicate with the LINE Messaging API.
+
+    To set this variable:
+    1.  Create a `.env` file in the root of the project.
+    2.  Add the following line to the `.env` file, replacing `your_line_channel_access_token` with your actual token:
+        ```
+        LINE_ACCESS_TOKEN=your_line_channel_access_token
+        ```
+
+### Other Environment Variables
+
+*   **`LINE_CHANNEL_SECRET`**: Your LINE Channel Secret. This is used to verify webhook requests from LINE.
+    Set this in your `.env` file as:
+    ```
+    LINE_CHANNEL_SECRET=your_line_channel_secret
+    ```
+
+*   **`OPENAI_MODEL`** (Optional): The OpenAI model to be used. Defaults to `gpt-4.1-mini` if not set.
+    You can set this in your `.env` file, for example:
+    ```
+    OPENAI_MODEL=gpt-4
+    ```

--- a/utils.py
+++ b/utils.py
@@ -13,7 +13,13 @@ client = AsyncOpenAI()
 
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
 
-cfg = Configuration(access_token=os.getenv("LINE_ACCESS_TOKEN"))
+line_access_token = os.getenv("LINE_ACCESS_TOKEN")
+if line_access_token is None:
+    raise ValueError(
+        "The LINE_ACCESS_TOKEN environment variable is not set. "
+        "Please set this variable to your LINE channel access token."
+    )
+cfg = Configuration(access_token=line_access_token)
 
 # -- LINE -------------------------------------------------------------
 async def show_loading(chat_id: str, seconds: int = 30):


### PR DESCRIPTION
The application would previously crash with a TypeError if the LINE_ACCESS_TOKEN environment variable was not set.

This commit introduces a check in `utils.py` to ensure that LINE_ACCESS_TOKEN is present. If it's not set, a ValueError is raised with an informative message.

Additionally, this commit:
- Creates a README.md file with setup instructions and details about required environment variables (LINE_ACCESS_TOKEN, LINE_CHANNEL_SECRET, OPENAI_MODEL).
- Updates .env.example to include LINE_ACCESS_TOKEN and adds comments explaining each variable.