### PR TITLE
Enable GAS chat logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ To run this project, you need to set up the following environment variables.
     ```
     OPENAI_MODEL=gpt-4
     ```
+
+*   **`GAS_LOG_URL`** (Optional): URL of your Google Apps Script endpoint to store chat logs.
+    Set it in your `.env` file as:
+    ```
+    GAS_LOG_URL=https://script.google.com/your-script-url
+    ```

--- a/utils.py
+++ b/utils.py
@@ -92,6 +92,28 @@ async def reply_or_push(user_id: str, reply_token: str, text: str):
             else:
                 raise
 
+# -- GAS ---------------------------------------------------------------
+async def log_to_gas(message_id: str, question: str, response: str, sheet_name: str | None = None):
+    """Send chat logs to Google Apps Script if GAS_LOG_URL is set."""
+    gas_url = os.getenv("GAS_LOG_URL")
+    if not gas_url:
+        return
+
+    payload = {
+        "messageId": message_id,
+        "question": question,
+        "response": response,
+    }
+    if sheet_name:
+        payload["sheetName"] = sheet_name
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            await client.post(gas_url, json=payload)
+    except Exception as e:
+        # ログ送信失敗時はエラーメッセージを表示するが処理は継続
+        print(f"GAS logging failed: {e}")
+
 # -- GPT --------------------------------------------------------------
 async def call_gpt_stream(user_id: str, user_msg: str) -> str:
     """OpenAI ChatCompletion をストリーム受信して結合（システムプロンプト対応）"""


### PR DESCRIPTION
## Summary
- describe `GAS_LOG_URL` env variable in README
- add `log_to_gas` helper to send chat logs
- record LINE message ID and log question & answer to GAS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673a613e80832bb375713e5820bbd0